### PR TITLE
debian: fix syntax error

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -17,35 +17,35 @@ Copyright:
 License: LGPL-3+
 
 License: LGPL-3+
-This program is free software: you can redistribute it and/or modify
-it under the terms of the Lesser GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-Lesser GNU General Public License for more details.
-.
-You should have received a copy of the Lesser GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-.
-On Debian systems, the full text of the Lesser GNU General Public License
-version 3.0 license can be found in `/usr/share/common-licenses/LGPL-3'.
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the Lesser GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ Lesser GNU General Public License for more details.
+ .
+ You should have received a copy of the Lesser GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the Lesser GNU General Public License
+ version 3.0 license can be found in `/usr/share/common-licenses/LGPL-3'.
 
 License: GPL-3+
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-.
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-.
-On Debian systems, the full text of the GNU General Public License version
-3.0 can be found in `/usr/share/common-licenses/GPL-3'.
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the full text of the GNU General Public License version
+ 3.0 can be found in `/usr/share/common-licenses/GPL-3'.


### PR DESCRIPTION
  W: hinawa-utils source: syntax-error-in-dep5-copyright line 20: Cannot parse line "This program is free software: you can redistribute it and/or modify"