### PR TITLE
debian: drop needless X-Python3-Version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends: debhelper (>= 11),
     python3-all,
     python3-setuptools
 Standards-Version: 4.1.4
-X-Python3-Version: >= 3.4
 Homepage: https://github.com/takaswie/hinawa-utils
 
 Package: python3-hinawa-utils


### PR DESCRIPTION
W: hinawa-utils source: ancient-python-version-field x-python3-version 3.4
N:
N:    The specified Python-Version or Python3-Version field is used to specify
N:    the version(s) of Python the package supports. However, the associated
N:    Python version is satisfied by the current "oldstable" distribution of
N:    Debian and is therefore unnecessary.
N:
N:    Please remove or update the reference.