### PR TITLE
dice extended: fix typo breaking store command

### DIFF
--- a/hinawa_utils/dice/dice_extended_unit.py
+++ b/hinawa_utils/dice/dice_extended_unit.py
@@ -143,7 +143,7 @@ class DiceExtendedUnit(DiceUnit):
         req = Hinawa.FwReq.new()
         rate = self._protocol.read_sampling_rate(req)
         mode = self._get_rate_mode(rate)
-        ExtCmdSpace(self._protocol, req, 'load-to-storage', mode)
+        ExtCmdSpace.initiate(self._protocol, req, 'load-to-storage', mode)
 
         # MEMO: however, in most models, configuration of router is stored by
         # 'load-from-router' command.


### PR DESCRIPTION
This PR fixes the config store command for dice extended devices.